### PR TITLE
Update EPExtensions.swift

### DIFF
--- a/EPCalendar/EPCalendarPicker/EPExtensions.swift
+++ b/EPCalendar/EPCalendarPicker/EPExtensions.swift
@@ -191,15 +191,3 @@ extension NSDate {
 
     }
 }
-
-func ==(lhs: NSDate, rhs: NSDate) -> Bool {
-    return lhs.compare(rhs) == NSComparisonResult.OrderedSame
-}
-
-func <(lhs: NSDate, rhs: NSDate) -> Bool {
-    return lhs.compare(rhs) == NSComparisonResult.OrderedAscending
-}
-
-func >(lhs: NSDate, rhs: NSDate) -> Bool {
-    return rhs.compare(lhs) == NSComparisonResult.OrderedAscending
-}


### PR DESCRIPTION
Removed custom date operators, now handled by Swift 3.0
